### PR TITLE
Update neuroimaging-afnibootcamp.md

### DIFF
--- a/pages/neuroimaging/neuroimaging-afnibootcamp.md
+++ b/pages/neuroimaging/neuroimaging-afnibootcamp.md
@@ -75,11 +75,13 @@ nifti_tool -disp_hdr -input T1.nii.gz
 
 ## Keeping up AFNI
 Update AFNI using:
+
 ```{bash, eval=FALSE}
 @update.afni.binaries
 ```
 
 To get the afni version number, type
+
 ```{bash, eval=FALSE}
 afni -ver
 ```


### PR DESCRIPTION
Preformatted needs a blank line before the triple backticks, I believe.